### PR TITLE
Bugfix: Transfer expiration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/mock-dfsp-backend",
-  "version": "8.3.1",
+  "version": "8.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/mock-dfsp-backend",
-  "version": "8.3.1",
+  "version": "8.3.2",
   "description": "A mock DFSP backend for Mojaloop SDK testing and learning",
   "main": "server.js",
   "scripts": {

--- a/src/server.js
+++ b/src/server.js
@@ -79,16 +79,16 @@ app.get('/parties/:idType/:idValue', async (req, res) => {
 app.post('/quoterequests', async (req, res) => {
     // always return zero fees
     console.log(`Quote request received: ${util.inspect(req.body)}`);
-
-    res.send({
+    const response = {
         quoteId: req.body.quoteId,
         transactionId: req.body.transactionId,
         transferAmount: req.body.amount,
         transferAmountCurrency: req.body.currency,
         payeeReceiveAmount: req.body.amount,
         payeeReceiveAmountCurrency: req.body.currency,
-        expiration: new Date().toISOString(),
-    });
+    }
+    if (req.body.expiration) response.expiration = req.body.expiration;
+    res.send(response);
 });
 
 


### PR DESCRIPTION
Fix:
 Stop the mock dfsp backend from overwriting expiration datetime set by the scheme-adapter. 